### PR TITLE
Hostname parsing

### DIFF
--- a/hosts.sublime-syntax
+++ b/hosts.sublime-syntax
@@ -41,6 +41,9 @@ variables:
       |(?:[0-9a-f]{1,4}:){0,5}   :[0-9a-f]{1,4}
       |(?:[0-9a-f]{1,4}:){0,6}   :
     ))
+  hostname_char: '[\w-]'
+  hostname_segment: (?:\w{{hostname_char}}{1,61}\w|\w\w?)
+  hostname_break: (?=[ \t#]|$)
 
 contexts:
   # The prototype context is prepended to all contexts but those setting
@@ -86,6 +89,7 @@ contexts:
       captures:
         1: punctuation.separator.mapping.hosts
         2: entity.name.label.hosts
+      push: expect-hostnames
     - match: '{{ipv6}}(?=\s|$)'
       scope: meta.ip-address.v6.hosts constant.numeric.integer.hexadecimal.hosts
       push: expect-hostnames
@@ -93,9 +97,37 @@ contexts:
   expect-hostnames:
     - match: (?=\n|\s*#)
       pop: true
-    - match: '[ \t]+([\w.-]+)'
+    - match: '[ \t]([.-])'
       captures:
-        1: meta.hostname.hosts
+        1: invalid.illegal.hostname.leading-character.hosts
+    - match: '[ \t]+([\w.-]{254,})(\.)?{{hostname_break}}'
+      captures:
+        1: invalid.illegal.hostname.too-long.hosts
+        2: punctuation.terminator.hosts
+    - match: '[ \t]+(?=\w)'
+      push: in-hostname
+
+  in-hostname:
+    - meta_content_scope: meta.hostname.hosts string.unquoted.hosts
+    - match: '-(?=[ \t#]|$)'
+      scope: invalid.illegal.hostname.trailing-character.hosts
+    - match: '{{hostname_char}}{64,}'
+      scope: invalid.illegal.hostname.too-long.hosts
+    - match: '(\.|-)*{{hostname_segment}}(\.|-)*(\.)(?!{{hostname_break}})'
+      scope: meta.string.subdomain.hosts
+      captures:
+        1: invalid.illegal.hostname.sequence.hosts
+        2: invalid.illegal.hostname.sequence.hosts
+        3: punctuation.separator.sequence.hosts
+    - match: '(\.|-)*{{hostname_segment}}(-)*(\.)?{{hostname_break}}'
+      scope: meta.hostname.hosts string.unquoted.hosts
+      captures:
+        1: invalid.illegal.hostname.sequence.hosts
+        2: invalid.illegal.hostname.trailing-character.hosts
+        3: punctuation.terminator.hosts
+      pop: true
+    - match: '[^\w.-]'
+      scope: invalid.illegal.hostname.character.hosts
 
   comments:
     - match: '#'

--- a/test/syntax_test_hosts
+++ b/test/syntax_test_hosts
@@ -2,8 +2,61 @@
 
 1.2.3.4  host
 #^^^^^^ constant.numeric.integer.decimal.hosts
- 1.2.3.4 space
+1.2.3.4  host.tld
+#^^^^^^ constant.numeric.integer.decimal.hosts
+#        ^^^^^^^^ meta.hostname string.unquoted
+#            ^ punctuation.separator.sequence
+ 1.2.3.4 space.
 #^^^^^^^ constant.numeric
+#             ^ punctuation.terminator
+
+# No hostname assigned
+1.2.3.4
+#^^^^^^ meta.ip-address constant.numeric
+#      ^ - meta
+
+# Invalid hostnames
+1.2.3.4  foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.fo
+#^^^^^^ meta.ip-address constant.numeric
+#        ^^^^^^^^^^^^^^^^^ invalid.illegal.hostname.too-long
+1.2.3.4  foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.foo.fooo.
+#^^^^^^ meta.ip-address constant.numeric
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - invalid.illegal
+1.2.3.4  baz.fooooooooooooooooooooooooo-ooooooooooooooooooooooooooooooooooooo.bar
+#^^^^^^ meta.ip-address constant.numeric
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.illegal.hostname.too-long
+1.2.3.4  fo?o.bar
+#^^^^^^ meta.ip-address constant.numeric
+#                ^ - meta
+#          ^ invalid.illegal.hostname.character
+1.2.3.4  .foo
+#^^^^^^ meta.ip-address constant.numeric
+#            ^ - meta
+#        ^ invalid.illegal.hostname.leading-character
+1.2.3.4  -foo
+#^^^^^^ meta.ip-address constant.numeric
+#            ^ - meta
+#        ^ invalid.illegal.hostname.leading-character
+1.2.3.4  foo-
+#^^^^^^ meta.ip-address constant.numeric
+#            ^ - meta
+#           ^ invalid.illegal.hostname.trailing-character
+1.2.3.4  -foo
+#^^^^^^ meta.ip-address constant.numeric
+#            ^ - meta
+#        ^ invalid.illegal.hostname.leading-character
+1.2.3.4  foo..bar
+#^^^^^^ meta.ip-address constant.numeric
+#                ^ - meta
+#           ^ invalid.illegal.hostname.sequence
+1.2.3.4  foo.-bar
+#^^^^^^ meta.ip-address constant.numeric
+#                ^ - meta
+#            ^ invalid.illegal.hostname.sequence
+1.2.3.4  foo-.bar
+#^^^^^^ meta.ip-address constant.numeric
+#                ^ - meta
+#           ^ invalid.illegal.hostname.sequence
 
 # localhost entries using IPv4 and IPv6
 127.0.0.1 localhost.localdomain localhost
@@ -233,10 +286,13 @@ fe80::7:8%eth0  a.link-local
 #^^^^^^^^^^^^^ meta.ip-address.v6.hosts constant.numeric
 #        ^ punctuation.separator.mapping
 #         ^^^^ entity.name.label
+#               ^^^^^^^^^^^^ meta.hostname.hosts
 fe80::7:8%1     b.link-local
 #^^^^^^^^^^ meta.ip-address.v6.hosts constant.numeric
 #        ^ punctuation.separator.mapping
 #         ^ entity.name.label
+#^ meta.ip-address.v6 constant.numeric
+#               ^^^^^^^^^^^^ meta.hostname.hosts
 
 # (IPv4-mapped IPv6 addresses and IPv4-translated addresses)
 ::255.255.255.255        a.ip4.mapped


### PR DESCRIPTION
This code is not exactly elegant, and I imagine there are edge cases I haven't handled.

One could also make [Punycode segments](https://en.wikipedia.org/wiki/Internationalized_domain_name#Example_of_IDNA_encoding) more visible, but this is a decent beginning.

```
  xn--bcher-kva.example.com
# ^^^^ punctuation.definition.string.begin.punycode.hosts
#          ^ punctuation.definition.constant.punycode.hosts
#           ^^^ constant.something?
  xn--p1ai
```