### PR TITLE
Add more thorough hostname highlighting

### DIFF
--- a/Symbol List.tmPreferences
+++ b/Symbol List.tmPreferences
@@ -4,7 +4,10 @@
     <key>name</key>
     <string>Symbol List</string>
     <key>scope</key>
-    <string>text.hosts meta.hostname</string>
+    <string>
+        text.hosts meta.hostname,
+        text.hosts meta.link-local
+    </string>
     <key>settings</key>
     <dict>
         <key>showInSymbolList</key>

--- a/hosts.sublime-syntax
+++ b/hosts.sublime-syntax
@@ -88,7 +88,7 @@ contexts:
       scope: meta.ip-address.v6.hosts constant.numeric.integer.hexadecimal.hosts
       captures:
         1: punctuation.separator.mapping.hosts
-        2: entity.name.label.hosts
+        2: meta.link-local.hosts entity.name.label.hosts
       push: expect-hostnames
     - match: '{{ipv6}}(?=\s|$)'
       scope: meta.ip-address.v6.hosts constant.numeric.integer.hexadecimal.hosts
@@ -100,32 +100,51 @@ contexts:
     - match: '[ \t]([.-])'
       captures:
         1: invalid.illegal.hostname.leading-character.hosts
-    - match: '[ \t]+([\w.-]{254,})(\.)?{{hostname_break}}'
+    - match: ([\w.-]{254,})(\.)?{{hostname_break}}
       captures:
         1: invalid.illegal.hostname.too-long.hosts
         2: punctuation.terminator.hosts
-    - match: '[ \t]+(?=\w)'
+    - match: (?=\w)
       push: in-hostname
 
   in-hostname:
     - meta_content_scope: meta.hostname.hosts string.unquoted.hosts
-    - match: '-(?=[ \t#]|$)'
+    - match: '-(?=\n|$)'
       scope: invalid.illegal.hostname.trailing-character.hosts
+      pop: true
+    - match: '-(?=[ \t#])'
+      scope: invalid.illegal.hostname.trailing-character.hosts
+    - match: (?:\.{2,}|\.-|-\.)
+      scope: invalid.illegal.hostname.sequence.hosts
     - match: '{{hostname_char}}{64,}'
       scope: invalid.illegal.hostname.too-long.hosts
-    - match: '(\.|-)*{{hostname_segment}}(\.|-)*(\.)(?!{{hostname_break}})'
-      scope: meta.string.subdomain.hosts
+    # Punycode segments
+    - match: \b(xn--)(?:{{hostname_char}}+(-))?(\w+)\b(?!\.?{{hostname_break}})
+      scope: meta.punycode.hosts
       captures:
-        1: invalid.illegal.hostname.sequence.hosts
-        2: invalid.illegal.hostname.sequence.hosts
-        3: punctuation.separator.sequence.hosts
-    - match: '(\.|-)*{{hostname_segment}}(-)*(\.)?{{hostname_break}}'
+        1: punctuation.definition.string.begin.punycode.hosts
+        2: punctuation.separator.mapping.hosts
+        3: constant.character.injection.hosts
+    - match: \b(xn--)(?:{{hostname_char}}+(-))?(\w+)\b(\.)?{{hostname_break}}
+      scope: meta.hostname.hosts string.unquoted.hosts meta.punycode.hosts
+      captures:
+        1: punctuation.definition.string.begin.punycode.hosts
+        2: punctuation.separator.mapping.hosts
+        3: constant.character.injection.hosts
+        4: punctuation.terminator.hosts
+      pop: true
+    # Normal segments
+    - match: '{{hostname_segment}}\b(?!\.?{{hostname_break}})'
+      scope: meta.string.subdomain.hosts
+    - match: '{{hostname_segment}}(\.)?{{hostname_break}}'
       scope: meta.hostname.hosts string.unquoted.hosts
       captures:
-        1: invalid.illegal.hostname.sequence.hosts
-        2: invalid.illegal.hostname.trailing-character.hosts
-        3: punctuation.terminator.hosts
+        1: punctuation.terminator.hosts
       pop: true
+    # Segment separators
+    - match: \.
+      scope: punctuation.separator.sequence.hosts
+    # Invalid hostname characters
     - match: '[^\w.-]'
       scope: invalid.illegal.hostname.character.hosts
 

--- a/test/syntax_test.hosts
+++ b/test/syntax_test.hosts
@@ -48,15 +48,26 @@
 1.2.3.4  foo..bar
 #^^^^^^ meta.ip-address constant.numeric
 #                ^ - meta
-#           ^ invalid.illegal.hostname.sequence
+#           ^^ invalid.illegal.hostname.sequence
 1.2.3.4  foo.-bar
 #^^^^^^ meta.ip-address constant.numeric
 #                ^ - meta
-#            ^ invalid.illegal.hostname.sequence
+#           ^^ invalid.illegal.hostname.sequence
 1.2.3.4  foo-.bar
 #^^^^^^ meta.ip-address constant.numeric
 #                ^ - meta
-#           ^ invalid.illegal.hostname.sequence
+#           ^^ invalid.illegal.hostname.sequence
+
+# Punycode hostnames
+::   xn--bcher-kva.example.com
+#    ^^^^ punctuation.definition.string.begin.punycode
+#             ^ punctuation.separator.mapping
+#              ^^^ constant.character.injection
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^ - string string
+::  xn--p1ai
+#   ^^^^ punctuation.definition.string.begin.punycode
+#       ^^^^ constant.character.injection
+
 
 # localhost entries using IPv4 and IPv6
 127.0.0.1 localhost.localdomain localhost
@@ -176,6 +187,7 @@ yolo.yoyo       random.characters
 1:2:3:4:5:6:7:8 a.example.com
 #^^^^^^^^^^^^^^ meta.ip-address.v6 constant.numeric
 #               ^^^^^^^^^^^^^ meta.hostname.hosts
+#               ^^^^^^^^^^^^^ - string string
 
 1::             b1.example.com
 #^^ meta.ip-address.v6 constant.numeric


### PR DESCRIPTION
This is slightly more robust in complaining about invalid sequences. It also adds highlighting and identification of punycode segments (one could add some Python to make a hover that internationalized them). Lastly, it adds link-local names to the <kbd>Cmd</kbd>+<kbd>R</kbd> menu.