### PR TITLE
Create .gitattributes trimming PC packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Skip packaging for ST download
+/.git* export-ignore
+/.github/** export-ignore
+/demo/** export-ignore


### PR DESCRIPTION
Stop including extraneous files in the `git archive` zip used to make the `*.sublime-package`.

By request of some community members, we're keeping the main README text and any syntax tests.